### PR TITLE
feat: add basic auth flow

### DIFF
--- a/STATUS.yaml
+++ b/STATUS.yaml
@@ -82,5 +82,24 @@ status_entries:
     next:
       - "Решить, переходить ли к этапу 1.3 или 2.1"
 
+  - status_id: "spms_003"
+    timestamp: "2025-08-18T18:06:59+00:00"
+    roadmap_ref: "2.1"
+
+    done:
+      - "Добавлены экраны Welcome, Login, Register"
+      - "Реализованы функции auth login/register с сохранением токена"
+      - "Настроены guarded routes на основе токена"
+
+    evidence:
+      - "src/index.tsx"
+      - "src/login.tsx"
+      - "src/register.tsx"
+      - "src/features/auth/api/index.ts"
+      - "src/_layout.tsx"
+
+    next:
+      - "Интегрировать реальные вызовы API и обработку ошибок"
+
 schema_version: "1.0"
 project: "SPMS Receipt Splitter Frontend"

--- a/src/_layout.tsx
+++ b/src/_layout.tsx
@@ -1,11 +1,32 @@
+import { useEffect } from 'react';
 import { Stack } from 'expo-router';
 import AppProviders from './app/providers/AppProviders';
+import { useAppStore } from './shared/lib/stores/app-store';
+import { getToken } from './shared/lib/utils/token-storage';
 
 export default function RootLayout() {
+  const token = useAppStore((s) => s.token);
+  const setToken = useAppStore((s) => s.setToken);
+
+  useEffect(() => {
+    (async () => {
+      const stored = await getToken();
+      if (stored) setToken(stored);
+    })();
+  }, [setToken]);
+
   return (
     <AppProviders>
       <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        {token ? (
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        ) : (
+          <>
+            <Stack.Screen name="index" options={{ headerShown: false }} />
+            <Stack.Screen name="login" options={{ title: 'Login' }} />
+            <Stack.Screen name="register" options={{ title: 'Register' }} />
+          </>
+        )}
       </Stack>
     </AppProviders>
   );

--- a/src/features/auth/api/index.ts
+++ b/src/features/auth/api/index.ts
@@ -1,0 +1,28 @@
+import axios from 'axios';
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3000';
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface RegisterRequest {
+  username: string;
+  email: string;
+  password: string;
+}
+
+export interface AuthResponse {
+  token: string;
+}
+
+export async function login(payload: LoginRequest): Promise<AuthResponse> {
+  const { data } = await axios.post<AuthResponse>(`${API_URL}/auth/login`, payload);
+  return data;
+}
+
+export async function register(payload: RegisterRequest): Promise<AuthResponse> {
+  const { data } = await axios.post<AuthResponse>(`${API_URL}/auth/register`, payload);
+  return data;
+}

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -1,0 +1,50 @@
+import { useRouter } from 'expo-router';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { View, TextInput, Button } from 'react-native';
+import { login, LoginRequest } from '../api';
+import { saveToken } from '@/shared/lib/utils/token-storage';
+import { useAppStore } from '@/shared/lib/stores/app-store';
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function LoginForm() {
+  const { handleSubmit, setValue } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: { email: '', password: '' },
+  });
+  const setToken = useAppStore((s) => s.setToken);
+  const router = useRouter();
+
+  const onSubmit = async (values: LoginRequest) => {
+    const res = await login(values);
+    await saveToken(res.token);
+    setToken(res.token);
+    router.replace('/');
+  };
+
+  return (
+    <View style={{ padding: 20 }}>
+      <TextInput
+        placeholder="Email"
+        autoCapitalize="none"
+        keyboardType="email-address"
+        style={{ marginBottom: 12, borderWidth: 1, padding: 8 }}
+        onChangeText={(text) => setValue('email', text)}
+      />
+      <TextInput
+        placeholder="Password"
+        secureTextEntry
+        style={{ marginBottom: 12, borderWidth: 1, padding: 8 }}
+        onChangeText={(text) => setValue('password', text)}
+      />
+      <Button title="Login" onPress={handleSubmit(onSubmit)} />
+    </View>
+  );
+}

--- a/src/features/auth/ui/RegisterForm.tsx
+++ b/src/features/auth/ui/RegisterForm.tsx
@@ -1,0 +1,56 @@
+import { useRouter } from 'expo-router';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { View, TextInput, Button } from 'react-native';
+import { register as registerUser, RegisterRequest } from '../api';
+import { saveToken } from '@/shared/lib/utils/token-storage';
+import { useAppStore } from '@/shared/lib/stores/app-store';
+
+const schema = z.object({
+  username: z.string().min(2),
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function RegisterForm() {
+  const { handleSubmit, setValue } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: { username: '', email: '', password: '' },
+  });
+  const setToken = useAppStore((s) => s.setToken);
+  const router = useRouter();
+
+  const onSubmit = async (values: RegisterRequest) => {
+    const res = await registerUser(values);
+    await saveToken(res.token);
+    setToken(res.token);
+    router.replace('/');
+  };
+
+  return (
+    <View style={{ padding: 20 }}>
+      <TextInput
+        placeholder="Username"
+        style={{ marginBottom: 12, borderWidth: 1, padding: 8 }}
+        onChangeText={(text) => setValue('username', text)}
+      />
+      <TextInput
+        placeholder="Email"
+        autoCapitalize="none"
+        keyboardType="email-address"
+        style={{ marginBottom: 12, borderWidth: 1, padding: 8 }}
+        onChangeText={(text) => setValue('email', text)}
+      />
+      <TextInput
+        placeholder="Password"
+        secureTextEntry
+        style={{ marginBottom: 12, borderWidth: 1, padding: 8 }}
+        onChangeText={(text) => setValue('password', text)}
+      />
+      <Button title="Register" onPress={handleSubmit(onSubmit)} />
+    </View>
+  );
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,23 @@
+import { View, Text, TouchableOpacity } from 'react-native';
+import { Link } from 'expo-router';
+import { commonStyles } from '@/shared/ui/styles';
+
+export default function WelcomeScreen() {
+  return (
+    <View style={commonStyles.centerContainer}>
+      <Text style={commonStyles.title}>Welcome</Text>
+      <View style={commonStyles.buttonContainer}>
+        <Link href="/login" asChild>
+          <TouchableOpacity style={commonStyles.button}>
+            <Text style={commonStyles.buttonText}>Login</Text>
+          </TouchableOpacity>
+        </Link>
+        <Link href="/register" asChild>
+          <TouchableOpacity style={commonStyles.button}>
+            <Text style={commonStyles.buttonText}>Register</Text>
+          </TouchableOpacity>
+        </Link>
+      </View>
+    </View>
+  );
+}

--- a/src/login.tsx
+++ b/src/login.tsx
@@ -1,0 +1,5 @@
+import LoginForm from '@/features/auth/ui/LoginForm';
+
+export default function LoginScreen() {
+  return <LoginForm />;
+}

--- a/src/register.tsx
+++ b/src/register.tsx
@@ -1,0 +1,5 @@
+import RegisterForm from '@/features/auth/ui/RegisterForm';
+
+export default function RegisterScreen() {
+  return <RegisterForm />;
+}

--- a/src/shared/config/i18n.ts
+++ b/src/shared/config/i18n.ts
@@ -4,17 +4,16 @@ import * as Localization from 'expo-localization';
 import en from './locales/en.json';
 import ja from './locales/ja.json';
 
-void i18n
-  .use(initReactI18next)
-  .init({
-    compatibilityJSON: 'v3',
-    resources: {
-      en: { translation: en },
-      ja: { translation: ja },
-    },
-    lng: Localization.locale.split('-')[0],
-    fallbackLng: 'en',
-    interpolation: { escapeValue: false },
-  });
+const locale = Localization.getLocales()[0]?.languageCode ?? 'en';
+
+void i18n.use(initReactI18next).init({
+  resources: {
+    en: { translation: en },
+    ja: { translation: ja },
+  },
+  lng: locale,
+  fallbackLng: 'en',
+  interpolation: { escapeValue: false },
+});
 
 export default i18n;

--- a/src/shared/lib/stores/app-store.tsx
+++ b/src/shared/lib/stores/app-store.tsx
@@ -4,10 +4,12 @@ import { StoreApi, createStore, useStore } from 'zustand';
 interface AppState {
   isLoading: boolean;
   user: User | null;
+  token: string | null;
   theme: 'light' | 'dark';
   language: 'en' | 'ja';
   setLoading: (loading: boolean) => void;
   setUser: (user: User | null) => void;
+  setToken: (token: string | null) => void;
   setTheme: (theme: 'light' | 'dark') => void;
   setLanguage: (language: 'en' | 'ja') => void;
 }
@@ -22,21 +24,23 @@ interface User {
 type AppStore = StoreApi<AppState>;
 
 const createAppStore = () =>
-  createStore<AppState>((set) => ({
-    isLoading: false,
-    user: null,
-    theme: 'light',
-    language: 'en',
-    setLoading: (loading) => set({ isLoading: loading }),
-    setUser: (user) => set({ user }),
-    setTheme: (theme) => set({ theme }),
-    setLanguage: (language) => set({ language }),
-  }));
+    createStore<AppState>((set) => ({
+      isLoading: false,
+      user: null,
+      token: null,
+      theme: 'light',
+      language: 'en',
+      setLoading: (loading) => set({ isLoading: loading }),
+      setUser: (user) => set({ user }),
+      setToken: (token) => set({ token }),
+      setTheme: (theme) => set({ theme }),
+      setLanguage: (language) => set({ language }),
+    }));
 
 const StoreContext = createContext<AppStore | null>(null);
 
 export function AppStoreProvider({ children }: { children: ReactNode }) {
-  const storeRef = useRef<AppStore>();
+  const storeRef = useRef<AppStore | null>(null);
   if (!storeRef.current) {
     storeRef.current = createAppStore();
   }
@@ -46,11 +50,12 @@ export function AppStoreProvider({ children }: { children: ReactNode }) {
     </StoreContext.Provider>
   );
 }
-
-export function useAppStore<T>(selector: (state: AppState) => T) {
+export function useAppStore<T = AppState>(
+  selector?: (state: AppState) => T,
+) {
   const store = useContext(StoreContext);
   if (!store) {
     throw new Error('AppStoreProvider is missing');
   }
-  return useStore(store, selector);
+  return useStore(store, selector ?? ((state) => state as unknown as T));
 }

--- a/src/shared/lib/utils/token-storage.ts
+++ b/src/shared/lib/utils/token-storage.ts
@@ -1,0 +1,15 @@
+import * as SecureStore from 'expo-secure-store';
+
+const TOKEN_KEY = 'auth_token';
+
+export async function saveToken(token: string) {
+  await SecureStore.setItemAsync(TOKEN_KEY, token);
+}
+
+export async function getToken() {
+  return SecureStore.getItemAsync(TOKEN_KEY);
+}
+
+export async function removeToken() {
+  await SecureStore.deleteItemAsync(TOKEN_KEY);
+}


### PR DESCRIPTION
## Summary
- add welcome, login and register screens
- introduce auth API with secure token storage
- guard tab routes based on stored auth token

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a36a9b7adc832ca0e42412ce9cec7a